### PR TITLE
add coverage reports to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,12 @@ jobs:
         run: uv run ruff check .
 
       - name: Run tests
-        run: uv run pytest -v
+        run: uv run pytest -v --cov-report=xml --cov-report=term
+      
+      - name: Submit to Coveralls
+        uses: coverallsapp/github-action@v2
+        # env:
+        #   NODE_COVERALLS_DEBUG: 1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.xml


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the CI workflow by adding coverage reporting to the test run and integrating submission to Coveralls for better code coverage tracking.

### Detailed summary
- Updated the `run` command in the `Run tests` step to include coverage reports: `--cov-report=xml --cov-report=term`.
- Added a new step named `Submit to Coveralls` using `coverallsapp/github-action@v2`.
- Configured the `Submit to Coveralls` step with `github-token` and `file` parameters.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->